### PR TITLE
Fail builds without menu

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,30 @@
+<!-- Mark up for Site Navigation Section-->
+<header class="header">
+  <nav class="main-nav navbar navbar-expand-lg {{ if not $.IsHome }}main-nav-colored{{ end }}">
+    <div class="container-fluid">
+      <a href="{{.Site.BaseURL}}" class="navbar-brand">
+        <img src="{{ .Site.Params.logo | absURL}}" alt="site-logo" />
+      </a>
+      <button class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#mainNav" aria-expanded="false">
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+
+      <div
+        class="collapse navbar-collapse nav-list"
+        id="mainNav"
+      >
+        <ul class="navbar-nav ml-auto">
+          {{ $currentPage := . }}
+          {{ $menu := .Site.Menus.main}}
+          {{range $index, $element := $menu}}
+          <li class="nav-item {{ if or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }} active{{ end }}">
+             <a class="nav-link scroll-to" href="{{ $.Site.BaseURL }}{{ .URL }}">{{.Name}}</a>
+          </li>
+          {{end}}
+        </ul>
+      </div>
+    </div>
+  </nav>
+</header>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -18,6 +18,10 @@
         <ul class="navbar-nav ml-auto">
           {{ $currentPage := . }}
           {{ $menu := .Site.Menus.main}}
+          {{ if eq $menu nil }}
+            {{/* if the menu is empty, something went wrong (see commit message), so we fail for now, until we come up with a better plan */}}
+            {{ .Site.ASSERT_MENU_IS_NOT_EMPTY_FAILURE_this_should_crash }}
+          {{ end }}
           {{range $index, $element := $menu}}
           <li class="nav-item {{ if or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }} active{{ end }}">
              <a class="nav-link scroll-to" href="{{ $.Site.BaseURL }}{{ .URL }}">{{.Name}}</a>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -20,7 +20,7 @@
           {{ $menu := .Site.Menus.main}}
           {{ if eq $menu nil }}
             {{/* if the menu is empty, something went wrong (see commit message), so we fail for now, until we come up with a better plan */}}
-            {{ .Site.ASSERT_MENU_IS_NOT_EMPTY_FAILURE_this_should_crash }}
+            {{ errorf "No menu detected. Failing the build, please try again. This is a known race condition. If in `hugo serve` mode, re-save `config.toml` or restart server" }}
           {{ end }}
           {{range $index, $element := $menu}}
           <li class="nav-item {{ if or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }} active{{ end }}">

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,9 @@
 [build]
 publish = "public"
-command = "hugo version; hugo mod get; hugo --minify; cp _redirects public/"
+command = 'hugo version; hugo mod get; count=0; until hugo --minify || (( count++ >= 10 )); do echo "\n\n------------\nRETRYING\n--------\n\n"; done; cp _redirects public/'
 
 [build.environment]
 HUGO_VERSION = "0.99.1"
 
 [context.deploy-preview]
-command = "hugo version; hugo mod get; hugo --minify -b $DEPLOY_PRIME_URL; cp _redirects public/"
+command = 'hugo version; hugo mod get; count=0; until hugo --minify -b $DEPLOY_PRIME_URL || (( count++ >= 10 )); do echo "\n\n------------\nRETRYING\n--------\n\n"; done; cp _redirects public/'


### PR DESCRIPTION
OK, so I came up with a small plan to at least make sure we don't put a site live without a menu.

Especially since in the multi-language version, the two menus seem to be independent; so the chance that you will put a website live with 2 working menus is now squared (e.g. if the chance was 0.8 in the Polish-only, it's not 0.64 -- and I think 0.8 is generous).

Please read through the individual commits (and not the squashed version below) to understand what is going on.

Basically we fail the build when there is no menu.
Then on netlify we (hopefully) retry up to 10 times to get a working build.

(and yes, it certainly happens that a build fails and a next `hugo` execution in a loop, only milliseconds later, same code, succeeds).