### PR TITLE
Add decap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
-The main website for hs3.pl.
+# The main website for hs3.pl
 
-In order to run the website locally:
+## In order to run the website locally
 
-- Install hugo: https://gohugo.io/installation/
+- Install hugo extended edition: https://gohugo.io/installation/
 - (Fork &) clone repo
 - Do a `git submodule update --init`
 - `hugo serve`
 - Go to http:/localhost:1313/
 
 Also read the [I18n notes](i18n.md) and the [calendar/event notes](calendar.md).
+
+## To contribute
+
+There are 2 main ways of contributing to the website.
+
+1. Create a PR with proposed changes from your fork of the repository.
+2. If you want to make a contribution in the ["projekty"](https://hs3.pl/projekty/) or ["zasoby"](https://hs3.pl/zasoby/) subpage, you can do so via [Decap CMS GUI](https://decapcms.org/). Go to https://hs3.pl/admin, create a personal account and add your contribution.
+
+Both ways of contribution require a review from the website's maintainers before the changes can be integrated.
+
+You can acccess Decap CMS via localhost at localhost:1313/admin. Be mindful that no matter where you access Decap CMS - whether running locally, or in your published site — it will always fetch and commit files in the hosted repository. You can read more about it [here](https://decapcms.org/docs/configuration-options/).

--- a/content/en/zasoby/czlonkostwo.md
+++ b/content/en/zasoby/czlonkostwo.md
@@ -1,6 +1,7 @@
 ---
 title: "Membership Hackerspace Trójmiasto"
 url: /en/resources/membership
+category: dokumentacja
 ---
 
 Hackerspace Trójmiasto is a non-profit organisation, supported by membership fees.

--- a/content/en/zasoby/ml-fun.md
+++ b/content/en/zasoby/ml-fun.md
@@ -1,6 +1,7 @@
 ---
 title: ML FUN
 tags: ["hs3", "machine learning", "akademia hs3"]
+category: edukacja
 ---
 
 # ML-FUN

--- a/content/pl/zasoby/czlonkostwo.md
+++ b/content/pl/zasoby/czlonkostwo.md
@@ -1,5 +1,6 @@
 ---
 title: "Członkostwo Hackerspace Trójmiasto"
+category: dokumentacja
 ---
 
 Hackerspace Trójmiasto jest organizacją non-profit utrzymywaną z dobrowolnych składek członkowskich. Zrzucamy się by opłacić wynajem przestrzeni, zakupić {{% link ref=/zasoby/chciejlista %}}potrzebny sprzęt{{% /link %}} i móc realizować {{% link ref=/zasoby/stypendia-hs3 %}}stypendia HS3{{% /link %}} oraz ciekawe {{% link ref=/wydarzenia %}}wydarzenia{{% /link %}}.

--- a/content/pl/zasoby/finanse.md
+++ b/content/pl/zasoby/finanse.md
@@ -2,6 +2,7 @@
 title: "Finanse Hackerspace Trójmiasto"
 tags: ["hackerspace", "finanse"]
 url: /finanse
+category: dokumentacja
 ---
 
 {{< finanse >}}

--- a/content/pl/zasoby/historia-hs3.md
+++ b/content/pl/zasoby/historia-hs3.md
@@ -1,6 +1,7 @@
 ---
 title: "Historia Hackerspace Trójmiasto"
 tags: ["hackerspace", "hs3"]
+category: dokumentacja
 ---
 
 Oficjalne otwarcie Hackerspace Trójmiasto odbyło się 2 lipca 2016 roku.

--- a/content/pl/zasoby/jak-dokumentowac.md
+++ b/content/pl/zasoby/jak-dokumentowac.md
@@ -1,4 +1,5 @@
 ---
 title: Jak dokumentować
 tags: ["hs3", "dokumentacja"]
+category: dokumentacja
 ---

--- a/content/pl/zasoby/kodeks-postepowania.md
+++ b/content/pl/zasoby/kodeks-postepowania.md
@@ -1,6 +1,7 @@
 ---
 title: Kodeks Postępowania Hackerspace Trójmiasto
 tags: ["hs3"]
+category: dokumentacja
 ---
 
 Niniejszy kodeks postępowania odnosi się do przestrzeni online Hackerspace Trójmiasto (Discord, GitHub, fora, komentarze, wydarzenia online i hybrydowe).

--- a/content/pl/zasoby/materialy-graficzne.md
+++ b/content/pl/zasoby/materialy-graficzne.md
@@ -1,6 +1,7 @@
 ---
 title: "Materiały graficzne"
 tags: ["hs3", "grafika"]
+category: grafika
 ---
 
 Sprawdź na <https://fishy-tile-b98.notion.site/8ba11351d77a407492b3691db7c43e42?v=f06acb96869c4f0a9ee7c2a9cd3ac068>

--- a/content/pl/zasoby/misja-hs3.md
+++ b/content/pl/zasoby/misja-hs3.md
@@ -1,6 +1,7 @@
 ---
 title: "Misja Hackerspace Trójmiasto"
 tags: ["hs3", "misja"]
+category: dokumentacja
 ---
 
 Misją Hackerspace Trójmiasto jest stworzenie otwartej przestrzeni technologicznej i budowanie społeczności ludzi wspierających się w rozwoju oraz dzielących wiedzą w przyjaznej atmosferze.

--- a/content/pl/zasoby/organizacja-wydarzen.md
+++ b/content/pl/zasoby/organizacja-wydarzen.md
@@ -1,6 +1,7 @@
 ---
 title: Organizacja wydarzeń w Hackerspace Trójmiasto
 tags: ["hs3", "wydarzenia"]
+category: wydarzenia
 ---
 
 # Checklista wydarzeniowa

--- a/content/pl/zasoby/regulamin-pracowni.md
+++ b/content/pl/zasoby/regulamin-pracowni.md
@@ -1,4 +1,5 @@
 ---
 title: Regulamin Pracowni Hackerspace Trójmiasto
 tags: ["hs3"]
+category: dokumentacja
 ---

--- a/content/pl/zasoby/relacja-codeme-to-hs3.md
+++ b/content/pl/zasoby/relacja-codeme-to-hs3.md
@@ -1,6 +1,7 @@
 ---
 title: CODE:ME a Hackerspace Trójmiasto
 tags: ["hs3"]
+category: dokumentacja
 ---
 
 Hackerspace Trójmiasto (HS3) jest społecznością założoną przy wsparciu Fundacji CODE:ME, która związana jest z edukacją w branży IT.

--- a/content/pl/zasoby/sprzet.md
+++ b/content/pl/zasoby/sprzet.md
@@ -1,6 +1,7 @@
 ---
 title: "Sprzęt"
 tags: ["hackerspace", "hs3", "hardware"]
+category: hardware
 ---
 
 Zobacz też: [Studio Hackerspace Trójmiasto](/projekty/studio-hs3)

--- a/content/pl/zasoby/stypendia-hs3.md
+++ b/content/pl/zasoby/stypendia-hs3.md
@@ -1,4 +1,5 @@
 ---
 title: "Stypendia Hackerspace Trójmiasto"
 tags: ["hs3", "edukacja", "stypendia"]
+category: edukacja
 ---

--- a/content/pl/zasoby/teoria-hackerspace.md
+++ b/content/pl/zasoby/teoria-hackerspace.md
@@ -1,6 +1,7 @@
 ---
 title: Teoria Hackerspace
 tags: ["hackerspace"]
+category: dokumentacja
 ---
 
 Tłumaczenie za <https://wiki.hackerspaces.org/Theory>. Większość poniższych materiałów dostępna w języku angielskim.

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,6 +20,8 @@
     <link rel="shortcut icon" href="{{"/images/favicon.ico" | absURL}}" type="image/x-icon" />
     <link rel="icon" href="{{"/images/favicon.png" | absURL}}" type="image/x-icon" />
 
+    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+
   {{ $calendarOutput := .OutputFormats.Get "Calendar" }}
   {{ if $calendarOutput }}
     <link ref="alternate" type="text/calendar" href="{{$calendarOutput.RelPermalink | absURL}}" />

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,0 +1,81 @@
+backend:
+  name: git-gateway
+  branch: main # Branch to update (optional; defaults to master)
+publish_mode: editorial_workflow # Enable review before integrating changes
+media_folder: "static/images/uploads" # Media files repo storage location
+public_folder: "/images/uploads" # The src attribute for uploaded media
+collections:
+  - name: "projekty" # Used in routes, e.g., /admin/collections/blog
+    label: "[PL] Projekty" # Used in the UI
+    folder: "content/pl/projekty" # The path to the folder where the documents are stored
+    create: true # Allow users to create new documents in this collection
+    slug: "{{slug}}" # Filename template, e.g., title.md
+    fields: # The fields for each document, usually in front matter
+      - {label: "Layout", name: "layout", widget: "hidden", default: "blog"}
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Featured Image", name: "featureImage", widget: "image", required: false}
+      - {label: "Body", name: "body", widget: "markdown"}
+      - {label: "Tags", name: "tags", widget: "list", allow_add: true}
+  - name: "projekty-en"
+    label: "[ENG] Projects"
+    folder: "content/en/projekty"
+    create: true
+    slug: "{{slug}}"
+    fields:
+      - {label: "Layout", name: "layout", widget: "hidden", default: "blog"}
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Featured Image", name: "featureImage", widget: "image", required: false}
+      - {label: "Body", name: "body", widget: "markdown"}
+      - {label: "Tags", name: "tags", widget: "list", allow_add: true}
+  - name: "zasoby"
+    label: "[PL] Zasoby"
+    summary: "{{fields.category}} {{title}}"
+    folder: "content/pl/zasoby"
+    create: true
+    slug: "{{slug}}"
+    sortable_fields: ['commit_date', 'title', 'tags', 'category']
+    fields:
+      - {label: "Layout", name: "layout", widget: "hidden", default: "blog"}
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Featured Image", name: "featureImage", widget: "image", required: false}
+      - {label: "Body", name: "body", widget: "markdown"}
+      - {label: "Tags", name: "tags", widget: "list", allow_add: true}
+      - label: "Category"
+        name: "category"
+        widget: "select"
+        multiple: true
+        options: 
+          - dokumentacja
+          - edukacja
+          - grafika
+          - hardware
+          - outside-the-box
+          - software
+          - wydarzenia
+        hint: "**Dokumentacja** dotyczy dokumentów, regulaminów i opisów, **edukacja** materiałów edukacyjnych, a **wydarzenia** tych związanych z eventami hs3. W **grafice** znajdziesz materiały graficzne i marketingowe. **Hardware** to urządzenia i narzędzia, a **software** oprogramowanie. **Outside-the-box** to kategoria dla osób, które nie chcą trzymać się schematów."
+  - name: "zasoby-en"
+    label: "[ENG] Resources"
+    folder: "content/en/zasoby"
+    create: true
+    slug: "{{slug}}"
+    summary: "{{fields.category}} {{title}}"
+    fields:
+      - {label: "Layout", name: "layout", widget: "hidden", default: "blog"}
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Featured Image", name: "featureImage", widget: "image", required: false}
+      - {label: "Body", name: "body", widget: "markdown"}
+      - {label: "Tags", name: "tags", widget: "list", allow_add: true}
+      - label: "Category"
+        name: "category"
+        widget: "select"
+        multiple: true
+        options: 
+          - dokumentacja
+          - edukacja
+          - grafika
+          - hardware
+          - outside-the-box
+          - software
+          - wydarzenia
+        hint: "**Dokumentacja** is for documents, rules and descriptions, **edukacja** is for educational materials, and **wydarzenia** for those connected with events in hs3. In **grafika** you can find graphic and marketing. **Hardware** are devices and tools and **software** is programs etc. **Out-of-the-box** is a category for people who think outside the box."
+

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex" />
+  <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+  <title>Content Manager</title>
+</head>
+<body>
+  <!-- Include the script that builds the page and powers Decap CMS -->
+  <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+  <script>
+    if (window.netlifyIdentity) {
+      window.netlifyIdentity.on("init", user => {
+        if (!user) {
+          window.netlifyIdentity.on("login", () => {
+            document.location.href = "/admin/";
+          });
+        }
+      });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Summary of changes
1. I've added Decap CMS, which creates a GUI under [hs3.pl/admin](https://hs3.pl/admin) to simplify updating the website. So far, I added an option to edit [zasoby](https://hs3.pl/zasoby/) and [projekty](https://hs3.pl/projekty/), both in polish and english version.
2. I've also added a `category` field in `zasoby` to have more options for sorting the resources of hs. You can find proposed categories [below](https://github.com/hs3city/hs3.pl/compare/main...MartaSien:hs3.pl:add-decap?expand=1#diff-2a71451a3327b5be51d2420abc4a205adb5de8531414203b316bf05f51b0d12dR47-R55).
3. I've added the description od Decap CMS to README

Aside from changes in this PR, for Decap CMS to work, a netlify account of hs3 must be configured according to this article:  https://decapcms.org/docs/add-to-your-site/#authentication 
