### PR TITLE
Add Decap CMS GitHub backend

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,6 +1,8 @@
 backend:
-  name: git-gateway
+  name: github
+  repo: hs3city/hs3.pl
   branch: main # Branch to update (optional; defaults to master)
+  open_authoring: true
 publish_mode: editorial_workflow # Enable review before integrating changes
 media_folder: "static/images/uploads" # Media files repo storage location
 public_folder: "/images/uploads" # The src attribute for uploaded media
@@ -8,6 +10,7 @@ collections:
   - name: "projekty" # Used in routes, e.g., /admin/collections/blog
     label: "[PL] Projekty" # Used in the UI
     folder: "content/pl/projekty" # The path to the folder where the documents are stored
+    media_folder: "static/images/projekty" # The path to the folder where images are stored
     create: true # Allow users to create new documents in this collection
     slug: "{{slug}}" # Filename template, e.g., title.md
     fields: # The fields for each document, usually in front matter
@@ -19,6 +22,7 @@ collections:
   - name: "projekty-en"
     label: "[ENG] Projects"
     folder: "content/en/projekty"
+    media_folder: "static/images/projekty"
     create: true
     slug: "{{slug}}"
     fields:
@@ -31,6 +35,7 @@ collections:
     label: "[PL] Zasoby"
     summary: "{{title}}"
     folder: "content/pl/zasoby"
+    media_folder: "static/images/zasoby"
     create: true
     slug: "{{slug}}"
     sortable_fields: ['commit_date', 'title', 'tags', 'category']
@@ -59,6 +64,7 @@ collections:
   - name: "zasoby-en"
     label: "[ENG] Resources"
     folder: "content/en/zasoby"
+    media_folder: "static/images/zasoby"
     create: true
     slug: "{{slug}}"
     summary: "{{title}}"


### PR DESCRIPTION
### Description

1. Changed `backend` from git to GitHub, to enable creating PRs with user's GitHub account. This way, PRs generated by Decap CMS won't be anonymous.
2. Changed default image folders for Decap CMS to point to the correct directories.

### Sources
- [documentation on GitHub backend](https://decapcms.org/docs/github-backend/)
- [documentation on media_folder](https://decapcms.org/docs/collection-folder/)

### To do:

- [ ] For this setup, there are adjustments necessary on [GitHub and Netlify](https://docs.netlify.com/security/secure-access-to-sites/oauth-provider-tokens/#using-an-authentication-provider)