### PR TITLE
Change media_folder

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -4,13 +4,13 @@ backend:
   branch: main # Branch to update (optional; defaults to master)
   open_authoring: true
 publish_mode: editorial_workflow # Enable review before integrating changes
-media_folder: "static/images/uploads" # Media files repo storage location
+media_folder: "/static/images/uploads" # Media files repo storage location
 public_folder: "/images/uploads" # The src attribute for uploaded media
 collections:
   - name: "projekty" # Used in routes, e.g., /admin/collections/blog
     label: "[PL] Projekty" # Used in the UI
     folder: "content/pl/projekty" # The path to the folder where the documents are stored
-    media_folder: "static/images/projekty" # The path to the folder where images are stored
+    media_folder: "/static/images/projekty" # The path to the folder where images are stored
     create: true # Allow users to create new documents in this collection
     slug: "{{slug}}" # Filename template, e.g., title.md
     fields: # The fields for each document, usually in front matter
@@ -22,7 +22,7 @@ collections:
   - name: "projekty-en"
     label: "[ENG] Projects"
     folder: "content/en/projekty"
-    media_folder: "static/images/projekty"
+    media_folder: "/static/images/projekty"
     create: true
     slug: "{{slug}}"
     fields:
@@ -35,7 +35,7 @@ collections:
     label: "[PL] Zasoby"
     summary: "{{title}}"
     folder: "content/pl/zasoby"
-    media_folder: "static/images/zasoby"
+    media_folder: "/static/images/zasoby"
     create: true
     slug: "{{slug}}"
     sortable_fields: ['commit_date', 'title', 'tags', 'category']
@@ -64,7 +64,7 @@ collections:
   - name: "zasoby-en"
     label: "[ENG] Resources"
     folder: "content/en/zasoby"
-    media_folder: "static/images/zasoby"
+    media_folder: "/static/images/zasoby"
     create: true
     slug: "{{slug}}"
     summary: "{{title}}"


### PR DESCRIPTION
Previously, `media_folder` path was relative:
- `media_folder: "static/images/projekty"`

Now, it's absolute from the repository root:
- `media_folder: "/static/images/projekty"`

Now images should be uploaded correctly using [Decap CMS](https://hs3.pl/admin/)

You can see the test PR here: https://github.com/hs3city/hs3.pl/pull/112