### PR TITLE
Change Decap CMS 'zasoby' public_folder path

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -38,7 +38,7 @@ collections:
     summary: "{{title}}"
     folder: "content/pl/zasoby"
     media_folder: "/static/images/zasoby"
-    public_folder: "/images/projekty"
+    public_folder: "/images/zasoby"
     create: true
     slug: "{{slug}}"
     sortable_fields: ['commit_date', 'title', 'tags', 'category']
@@ -68,7 +68,7 @@ collections:
     label: "[ENG] Resources"
     folder: "content/en/zasoby"
     media_folder: "/static/images/zasoby"
-    public_folder: "/images/projekty"
+    public_folder: "/images/zasoby"
     create: true
     slug: "{{slug}}"
     summary: "{{title}}"


### PR DESCRIPTION
This should fix a bug visible in this PR: https://github.com/hs3city/hs3.pl/pull/116

Image path in posts added by Decap CMS in `zasoby` was pointing to `projekty` directory.