### PR TITLE
Add linux day redirect

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -12,3 +12,4 @@
 /spaceapi.json			https://spaceapi.in.hs3.pl/	307
 /gvt			https://www.meetup.com/pl-PL/hs3city/events/
 /gvt-video			https://www.youtube.com/playlist?list=PL97f0is2Y4VnWVgBYOlmYNJIRINzCwPvz
+/linuxday           https://hs3.pl/wydarzenia/2025/02/08/2025-02-08-linux-day-x-tlug/


### PR DESCRIPTION
This is just a minor change to add a redirect for the [Linux Day x TLUG](https://hs3.pl/linuxday) event