### PR TITLE
Set baseURL to fix absolute urls

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,4 @@
+baseURL = "https://hs3.pl/"
 languageCode = 'pl-pl'
 paginate = 9
 theme = "coHub"


### PR DESCRIPTION
Set baseUrl property, so that hugo properly generates absolute URLs for static scripts referenced in footer.js