### PR TITLE
HS3 model iframe - fix w3 validator errors

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -1,3 +1,7 @@
+iframe {
+  border: none;
+}
+  
 .main-nav .navbar-nav .nav-item .nav-link {
   &::first-letter {
     // capitalize on whole string makes "about us" to "About Us". We want "About us"

--- a/layouts/partials/hs3model.html
+++ b/layouts/partials/hs3model.html
@@ -1,10 +1,9 @@
 <section>
-    <div class="container">
-            <div class="sketchfab-embed-wrapper">
-                <iframe title="HS3 - Hackerspace Trojmiasto" allowfullscreen width="100%" height="480"
-                    allow="autoplay; fullscreen; xr-spatial-tracking" xr-spatial-tracking
-                    src="https://sketchfab.com/models/cd86faffc47d49e7b0c9261a2f51f472/embed">
-                </iframe>
-            </div>
-    </div>
+  <div class="container">
+    <iframe title="HS3 - Hackerspace Trojmiasto 3D model"
+      allowfullscreen width="100%" height="480"
+      allow="autoplay; fullscreen; xr-spatial-tracking"
+      src="https://sketchfab.com/models/cd86faffc47d49e7b0c9261a2f51f472/embed">
+    </iframe>
+  </div>
 </section>

--- a/layouts/partials/hs3model.html
+++ b/layouts/partials/hs3model.html
@@ -1,9 +1,8 @@
 <section>
     <div class="container">
             <div class="sketchfab-embed-wrapper">
-                <iframe title="HS3 - Hackerspace Trojmiasto" frameborder="0" allowfullscreen width="100%" height="480px"
-                    mozallowfullscreen="true" webkitallowfullscreen="true" allow="autoplay; fullscreen; xr-spatial-tracking"
-                    xr-spatial-tracking execution-while-out-of-viewport execution-while-not-rendered web-share
+                <iframe title="HS3 - Hackerspace Trojmiasto" allowfullscreen width="100%" height="480"
+                    allow="autoplay; fullscreen; xr-spatial-tracking" xr-spatial-tracking
                     src="https://sketchfab.com/models/cd86faffc47d49e7b0c9261a2f51f472/embed">
                 </iframe>
             </div>


### PR DESCRIPTION
It closes issue #136 

Fixing some errors pointed out by w3 validator, removing unnecessary `div`

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe