### PR TITLE
Track discord events

### DIFF
--- a/.github/workflows/kronos-local.yml
+++ b/.github/workflows/kronos-local.yml
@@ -1,21 +1,22 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Update calendar local
+name: Update Calendar
 
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  # Run every 3 hours
+  schedule:
+    - cron: '0 */3 * * *'
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "update"
+  group: 'update'
   cancel-in-progress: false
 
 env:
   DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
 
 jobs:
-  # Run Python script to fetch REST API info
   update:
     runs-on: ubuntu-latest
     permissions:
@@ -25,18 +26,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: '3.12'
+
       - name: Install dependencies
         working-directory: ./automation/kronos
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Generate files
+
+      - name: Update Discord events
         working-directory: ./automation/kronos
-        run: python kronos.py
+        run: |
+          python kronos.py
+          if [ $? -ne 0 ]; then
+            echo "Script failed with exit code $?"
+            exit $?
+          fi
+
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/automation/kronos/add_discord_events.py
+++ b/automation/kronos/add_discord_events.py
@@ -1,58 +1,75 @@
 import logging
 
 import yaml
+from pytz import timezone
 from sanitize import remove_emoji, sanitize
 
+local_timezone = timezone("Europe/Warsaw")
 
-async def add_discord_events(client, event_dir, local_timezone):
+
+class MyDumper(yaml.Dumper):
+    def increase_indent(self, flow=False, indentless=False):
+        return super(MyDumper, self).increase_indent(flow, False)
+
+
+def _process_event(event, event_dir):
+    logging.info(f"Proicessing event: {event.name}...")
+    logging.info(
+        f"Creator: {event.creator} [{event.creator_id}], description: {event.description}, time: {event.start_time}"
+    )
+    start_time = event.start_time.astimezone(local_timezone)
+    end_time = event.end_time.astimezone(local_timezone)
+
+    front_matter = {
+        "title": remove_emoji(event.name),
+        "tags": ["hs3"],
+        "outputs": ["html", "calendar"],
+        "discord_event": {
+            "id": event.id,
+            "link": event.url,
+            "interested": event.user_count,
+            "organizer": event.creator.name,
+            "location": event.location,
+        },
+        "eventInfo": {
+            "dates": {
+                "extra": {
+                    f"{start_time.strftime('%Y-%m-%d %H:%M')}-{end_time.strftime('%H:%M')}": None
+                }
+            }
+        },
+    }
+
+    if event.cover_image:
+        front_matter["featureImage"] = event.cover_image.url
+
+    file_content = f"""\
+---
+{yaml.dump(front_matter, Dumper=MyDumper, sort_keys=False, allow_unicode=True)}
+---
+
+{event.description or ""}
+"""
+    logging.info(f"Event file data:\n{file_content}")
+
+    date_path = event_dir.joinpath(start_time.strftime("%Y/%m/%d"))
+    filename = f"{start_time.strftime('%Y-%m-%d')}-{sanitize(event.name)}.md"
+    file_path = date_path / filename
+
+    try:
+        date_path.mkdir(parents=True, exist_ok=True)
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write(file_content)
+        logging.info(f"Created event file '{file_path}'")
+    except Exception as e:
+        logging.exception(f"Failed to write '{file_path}': {str(e)}")
+        raise
+
+
+async def add_discord_events(client, event_dir):
     for guild in client.guilds:
-        logging.info(f"Processing guild: {guild.name}")
+        logging.info(f"Scraping guild: {guild.name}")
 
         for event in guild.scheduled_events:
             event = await guild.fetch_scheduled_event(event.id)
-            start_time = event.start_time.astimezone(local_timezone)
-            end_time = event.end_time.astimezone(local_timezone)
-
-            front_matter = {
-                "title": remove_emoji(event.name),
-                "tags": ["hs3"],
-                "outputs": ["html", "calendar"],
-                "discord_event": {
-                    "id": event.id,
-                    "link": event.url,
-                    "interested": event.user_count,
-                    "organizer": event.creator.name,
-                    "location": event.location or "Online",
-                },
-                "eventInfo": {
-                    "dates": {
-                        "extra": {
-                            f"{start_time.strftime('%Y-%m-%d %H:%M')}-{end_time.strftime('%H:%M')}": None
-                        }
-                    }
-                },
-            }
-
-            # Add cover image if available
-            if event.cover_image:
-                front_matter["featureImage"] = event.cover_image.url
-
-            # Prepare the complete file content
-            class MyDumper(yaml.Dumper):
-                def increase_indent(self, flow=False, indentless=False):
-                    return super(MyDumper, self).increase_indent(flow, False)
-
-            file_content = f"---\n{yaml.dump(front_matter, Dumper=MyDumper, sort_keys=False, allow_unicode=True)}---\n\n{event.description or ''}"
-
-            # Create directory structure
-            date_path = event_dir.joinpath(start_time.strftime("%Y/%m/%d"))
-            filename = f"{start_time.strftime('%Y-%m-%d')}-{sanitize(event.name)}.md"
-
-            try:
-                date_path.mkdir(parents=True, exist_ok=True)
-                with open(date_path / filename, "w", encoding="utf-8") as f:
-                    f.write(file_content)
-                logging.info(f"Created: {date_path}/{filename}")
-            except Exception as e:
-                logging.error(f"Failed to write {filename}: {str(e)}")
-                raise
+            _process_event(event, event_dir)

--- a/automation/kronos/add_discord_events.py
+++ b/automation/kronos/add_discord_events.py
@@ -1,0 +1,58 @@
+import logging
+
+import yaml
+from sanitize import remove_emoji, sanitize
+
+
+async def add_discord_events(client, event_dir, local_timezone):
+    for guild in client.guilds:
+        logging.info(f"Processing guild: {guild.name}")
+
+        for event in guild.scheduled_events:
+            event = await guild.fetch_scheduled_event(event.id)
+            start_time = event.start_time.astimezone(local_timezone)
+            end_time = event.end_time.astimezone(local_timezone)
+
+            front_matter = {
+                "title": remove_emoji(event.name),
+                "tags": ["hs3"],
+                "outputs": ["html", "calendar"],
+                "discord_event": {
+                    "id": event.id,
+                    "link": event.url,
+                    "interested": event.user_count,
+                    "organizer": event.creator.name,
+                    "location": event.location or "Online",
+                },
+                "eventInfo": {
+                    "dates": {
+                        "extra": {
+                            f"{start_time.strftime('%Y-%m-%d %H:%M')}-{end_time.strftime('%H:%M')}": None
+                        }
+                    }
+                },
+            }
+
+            # Add cover image if available
+            if event.cover_image:
+                front_matter["featureImage"] = event.cover_image.url
+
+            # Prepare the complete file content
+            class MyDumper(yaml.Dumper):
+                def increase_indent(self, flow=False, indentless=False):
+                    return super(MyDumper, self).increase_indent(flow, False)
+
+            file_content = f"---\n{yaml.dump(front_matter, Dumper=MyDumper, sort_keys=False, allow_unicode=True)}---\n\n{event.description or ''}"
+
+            # Create directory structure
+            date_path = event_dir.joinpath(start_time.strftime("%Y/%m/%d"))
+            filename = f"{start_time.strftime('%Y-%m-%d')}-{sanitize(event.name)}.md"
+
+            try:
+                date_path.mkdir(parents=True, exist_ok=True)
+                with open(date_path / filename, "w", encoding="utf-8") as f:
+                    f.write(file_content)
+                logging.info(f"Created: {date_path}/{filename}")
+            except Exception as e:
+                logging.error(f"Failed to write {filename}: {str(e)}")
+                raise

--- a/automation/kronos/delete_future_discord_events.py
+++ b/automation/kronos/delete_future_discord_events.py
@@ -4,8 +4,8 @@ import logging
 import yaml
 
 
-def delete_future_discord_events(event_dir, local_timezone):
-    today = datetime.datetime.now(local_timezone).date()
+def delete_future_discord_events(event_dir):
+    today = datetime.date.today()
     logging.info(f"Current date: {today}, deleting future Discord events...")
 
     for year_dir in event_dir.glob("*"):
@@ -30,7 +30,9 @@ def delete_future_discord_events(event_dir, local_timezone):
                     )
                     continue
 
-                if event_date < today:
+                # Ignore today's events, even if they were deleted,
+                # otherwise we may remove an event that was already finished (and was removed automatically in Discord)
+                if event_date <= today:
                     continue
 
                 for event_file in day_dir.glob("*.md"):

--- a/automation/kronos/delete_future_discord_events.py
+++ b/automation/kronos/delete_future_discord_events.py
@@ -1,0 +1,59 @@
+import datetime
+import logging
+
+import yaml
+
+
+def delete_future_discord_events(event_dir, local_timezone):
+    today = datetime.datetime.now(local_timezone).date()
+    logging.info(f"Current date: {today}, deleting future Discord events...")
+
+    for year_dir in event_dir.glob("*"):
+        if not year_dir.is_dir() or not year_dir.name.isdigit():
+            continue
+
+        for month_dir in year_dir.glob("*"):
+            if not month_dir.is_dir() or not month_dir.name.isdigit():
+                continue
+
+            for day_dir in month_dir.glob("*"):
+                if not day_dir.is_dir() or not day_dir.name.isdigit():
+                    continue
+
+                try:
+                    event_date = datetime.date(
+                        int(year_dir.name), int(month_dir.name), int(day_dir.name)
+                    )
+                except ValueError as e:
+                    logging.warning(
+                        f"Invalid date format: {year_dir.name}-{month_dir.name}-{day_dir.name}: {e}"
+                    )
+                    continue
+
+                if event_date < today:
+                    continue
+
+                for event_file in day_dir.glob("*.md"):
+                    is_discord_event = False
+
+                    try:
+                        with open(event_file, "r", encoding="utf-8") as f:
+                            content = f.read()
+
+                        if content.startswith("---"):
+                            _, front_matter, _ = content.split("---", 2)
+                            metadata = yaml.safe_load(front_matter)
+                            if metadata and "discord_event" in metadata:
+                                is_discord_event = True
+
+                        if is_discord_event:
+                            logging.info(f"Deleting Discord event '{event_file}'")
+                            event_file.unlink()
+                        else:
+                            logging.info(f"Ignoring non-Discord event '{event_file}'")
+
+                    except Exception as e:
+                        logging.error(f"Error processing event '{event_file}': {e}")
+                        raise
+
+    logging.info("Done deleting future Discord events")

--- a/automation/kronos/kronos.py
+++ b/automation/kronos/kronos.py
@@ -8,7 +8,6 @@ import discord
 from add_discord_events import add_discord_events
 from delete_future_discord_events import delete_future_discord_events
 from dotenv import load_dotenv
-from pytz import timezone
 
 # Relative path to Hugo website events directory
 relative_event_dir = "../../content/pl/wydarzenia"
@@ -24,8 +23,6 @@ logging.basicConfig(level=logging.INFO)
 # Discord configuration
 intents = discord.Intents.default()
 client = discord.Client(intents=intents)
-
-local_timezone = timezone("Europe/Warsaw")
 
 
 async def connect_discord():
@@ -46,8 +43,8 @@ async def main():
     try:
         await connect_discord()
 
-        delete_future_discord_events(event_dir, local_timezone)
-        await add_discord_events(client, event_dir, local_timezone)
+        delete_future_discord_events(event_dir)
+        await add_discord_events(client, event_dir)
         logging.info("Successfully processed all Discord events")
         return 0
 

--- a/automation/kronos/kronos.py
+++ b/automation/kronos/kronos.py
@@ -1,22 +1,22 @@
-import json
+import asyncio
 import logging
 import os
+import sys
+from pathlib import Path
 
 import discord
-from pathlib import Path
-from pytz import timezone
+from add_discord_events import add_discord_events
+from delete_future_discord_events import delete_future_discord_events
 from dotenv import load_dotenv
-
-from sanitize import sanitize, remove_emoji
+from pytz import timezone
 
 # Relative path to Hugo website events directory
 relative_event_dir = "../../content/pl/wydarzenia"
-
 cwd = Path.cwd()
+event_dir = (cwd / relative_event_dir).resolve()
 
 load_dotenv(verbose=True)
 discord_token = os.getenv("DISCORD_TOKEN")
-event_dir = (cwd / relative_event_dir).resolve()
 
 # Logging configuration
 logging.basicConfig(level=logging.INFO)
@@ -28,69 +28,41 @@ client = discord.Client(intents=intents)
 local_timezone = timezone("Europe/Warsaw")
 
 
-@client.event
-async def on_ready():
-    guilds_total = len(client.guilds)
-    guilds_processed = 0
-    for guild in client.guilds:
-        guilds_processed += 1
-        logging.info(f"Scraping {guild}")
-        logging.info(f"{client.user} has connected to Discord server {guild}!")
-        for event in guild.scheduled_events:
-            full_event = await guild.fetch_scheduled_event(event.id)
-            event = full_event
-            start_time = event.start_time.astimezone(local_timezone)
-            end_time = event.end_time.astimezone(local_timezone)
-            logging.info(event)
-            logging.info(event.creator)
-            logging.info(event.creator_id)
-            logging.info(event.description)
-            logging.info(start_time)
-            date = start_time.strftime("%Y-%m-%d")
-            directory = event_dir.joinpath(start_time.strftime("%Y/%m/%d"))
-            print(directory)
-            start_time = start_time.strftime("%H:%M")
-            end_time = end_time.strftime("%H:%M")
-            filename = f"{date}-{sanitize(event.name)}.md"
-            if event.cover_image is not None:
-                feature_image = f"featureImage: {event.cover_image.url}"
-            else:
-                feature_image = ""
-            fields = f"""---
-title: {json.dumps(remove_emoji(event.name))}
-tags: ["hs3"]
-outputs:
-- html
-- calendar
-discord_event:
-  id: {json.dumps(event.id)}
-  link: {json.dumps(event.url)}
-  interested: {json.dumps(event.user_count)}
-  organizer: {json.dumps(event.creator.name)}
-  location: {json.dumps(event.location)}
-{feature_image}
-eventInfo:
-  dates:
-    extra:
-      {date} {start_time}-{end_time}: null
----
-{event.description}
-"""
-            print(fields)
-            try:
-                os.makedirs(directory, mode=0o777, exist_ok=True)
-            except FileExistsError:
-                logging.exception("We can't create a tree. Why, oh why?")
-            try:
-                with open(directory.joinpath(filename), "w", encoding="utf-8") as f:
-                    f.write(fields)
-            except PermissionError:
-                logging.exception("Oops, we can't write here!")
-        logging.info(
-            f"Guilds processed: {guilds_processed}, guilds total: {guilds_total}"
-        )
-        if guilds_processed == guilds_total:
+async def connect_discord():
+    logging.info("Starting Discord client...")
+    connected = asyncio.Event()
+
+    async def on_ready():
+        connected.set()
+
+    client.event(on_ready)
+    await client.login(discord_token)
+    asyncio.create_task(client.connect(reconnect=False))
+    await asyncio.wait_for(connected.wait(), timeout=30.0)
+    logging.info("Discord client started")
+
+
+async def main():
+    try:
+        await connect_discord()
+
+        delete_future_discord_events(event_dir, local_timezone)
+        await add_discord_events(client, event_dir, local_timezone)
+        logging.info("Successfully processed all Discord events")
+        return 0
+
+    except asyncio.TimeoutError:
+        logging.error("Timeout while connecting to Discord")
+        return 1
+    except Exception as e:
+        logging.error(f"Error during processing: {e}")
+        return 2
+    finally:
+        if client.is_ready():
             await client.close()
 
 
-client.run(discord_token)
+if __name__ == "__main__":
+    exit_code = asyncio.run(main())
+    logging.info(f"Finished processing discord events, exit code: {exit_code}")
+    sys.exit(exit_code)

--- a/automation/kronos/requirements.txt
+++ b/automation/kronos/requirements.txt
@@ -1,3 +1,4 @@
-discord.py==2.4.0 # https://pypi.org/project/discord.py/
-python-dotenv==1.0.1 # https://pypi.org/project/python-dotenv/
-pytz==2024.2 # https://pypi.org/project/pytz/
+discord.py==2.4.0
+python-dotenv==1.0.1
+pytz==2025.2
+PyYAML==6.0.2


### PR DESCRIPTION
Remove any **future** discord events that were deleted from Discord. This way we clean up any cancelled events and avoid duplicates if an event was renamed (changing the filename). This ignores:
- Past and today events
- Non-discord events (based on yaml data)

This may still cause a duplicate if today's event got renamed, but that's less likely. We can also use event IDs for filenames to handle that, but that would reduce readability by a lot, doesn't seem worth it.

And minor changes
- Refactored stuff, too much code for one file
- Updated pipeline to call this every 3 hours
- Using `yaml` lib to process yaml parts of the events. This changes some formatting on the events, but nothing major and Hugo should handle it just as well.
- Using continuous async code flow when connecting to discord bot, giving better and easier control than `on_ready` event method.