### PR TITLE
Fixes #90: an easy way to jump straight into calendar view

### DIFF
--- a/assets/js/eventViews.ts
+++ b/assets/js/eventViews.ts
@@ -9,6 +9,10 @@ if (!(globalThis as any).eventViewsRun) {
     document.querySelectorAll(".eventDates").forEach((el) => {
       fixTabs(el as HTMLDivElement);
       createEventViewsForDiv(el as HTMLDivElement);
+      if (window.location.hash !== "") {
+        const tabName = window.location.hash.slice(1)
+        selectTab(el as HTMLDivElement, tabName)
+      }
     });
   }
 
@@ -30,6 +34,21 @@ if (!(globalThis as any).eventViewsRun) {
     image: string | undefined;
   }
 
+  function selectTab(parentElement: HTMLDivElement, tabToSelect: string) {
+    const tabs = [
+      ...parentElement.querySelectorAll(".grid-tab"),
+    ] as HTMLElement[];
+    const allTabs = tabs.map((el) => el.classList[1]);
+    if (allTabs.indexOf(tabToSelect) === -1) {
+      console.warn(
+        `Cannot select tab ${tabToSelect}, does not exist in ${allTabs.join(", ")}`)
+      return
+    }
+    allTabs.forEach((klass) => parentElement.classList.remove(klass));
+    parentElement.classList.add(tabToSelect)
+    window.location.hash = `#${tabToSelect}`
+  }
+
   function fixTabs(parentElement: HTMLDivElement) {
     const tabs = [
       ...parentElement.querySelectorAll(".grid-tab"),
@@ -37,8 +56,7 @@ if (!(globalThis as any).eventViewsRun) {
     const all_classes = tabs.map((el) => el.classList[1]);
     tabs.forEach((tab) => {
       tab.addEventListener("click", () => {
-        all_classes.forEach((klass) => parentElement.classList.remove(klass));
-        parentElement.classList.add(tab.classList[1]);
+        selectTab(parentElement, tab.classList[1])
       });
     });
   }


### PR DESCRIPTION
This commit updates the document hash part every time a tab is clicked. When the page is loaded it tries to open the tab that has the hash as name.

Limitations:
- If there are multiple event lists on a single page (I don't think we have that right now) this will influence all event lists
- If there is anything else on the page depending on or reaction to the document hash, things will obviously end badly.


@DoomHammer sanity check please :)