### PR TITLE
Add .well-known Matrix server config

### DIFF
--- a/.well-known/matrix/server
+++ b/.well-known/matrix/server
@@ -1,0 +1,3 @@
+{
+    "m.server": "matrix.in.hs3.pl:8448"
+}


### PR DESCRIPTION
Add a [.well-known](https://en.wikipedia.org/wiki/Well-known_URI) configuration for [\[matrix\]](https://matrix.org/), so that we can use the `hs3.pl` domain as the [homeserver](https://matrix.org/docs/matrix-concepts/elements-of-matrix/#homeserver) identifier, even when the server is exposed on a different subdomain.