### PR TITLE
Add redirect for /db to HS3 inventory database

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -16,3 +16,4 @@
 /workshopping https://docs.google.com/spreadsheets/d/1SAU_a3OohKst0FHJ1HzmE-uEbp0itiqxBrbpCIO0T84/edit?gid=1002977074#gid=1002977074
 /.well-known/matrix/*  https://matrix.in.hs3.pl/.well-known/matrix/:splat
 /_matrix/*      https://matrix.in.hs3.pl:8448/_matrix/:splat
+/db/*     https://kb.hs3.pl/t/:splat                


### PR DESCRIPTION
This way, we can produce a set of universal stickers with QR codes to the HS3 inventory database.

Example:
- https://hs3.pl/db/41 -> https://kb.hs3.pl/t/41