### PR TITLE
Switch Discord event link to hs3.pl/join URL

### DIFF
--- a/automation/kronos/add_discord_events.py
+++ b/automation/kronos/add_discord_events.py
@@ -31,7 +31,7 @@ def _process_event(event, event_dir):
         "outputs": ["html", "calendar"],
         "discord_event": {
             "id": event.id,
-            "link": event.url,
+            "link": "https://hs3.pl/join",
             "interested": event.user_count,
             "organizer": event.creator.name,
             "location": event.location,


### PR DESCRIPTION
Discord event link works only for hs3 discord channel members.